### PR TITLE
Including files support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,26 @@ Deploys and retrieve artifacts from a Maven Repository Manager.
 ### `check`: Check for new versions of the artifact.
 
 Checks for new versions of the artifact by retrieving the `maven-metadata.xml` from
-the repository.
+the repository. Check will only look for new versions of the artifact, not any auxillary artifacts such as javadoc.
 
 
 ### `in`: Fetch an artifact from a repository.
 
 Download the artifact from the repository.
+
+#### Parameters
+
+* `artifactItems`: *Optional.* Map of auxillary artifacts to download alongside the primary artifact. Takes the form _classifier: type_. It's expected auxillary artifacts will follow normal naming conventions. E.g. if the primary artifact is `my-webapp-0.0.1-beta.rc-2.jar`, then the parameter `javadoc: jar` will search for `my-webapp-0.0.1-beta.rc-2-javadoc.jar`.
+
+``` yaml
+- get: artifact
+  params:
+    artifactItems:
+      javadoc: jar
+      sources: jar
+      diagram: pdf
+      classifier: packagingType
+```
 
 
 ### `out`: Deploy artifact to a repository.
@@ -59,6 +73,16 @@ Deploy the artifact to the Maven Repository Manager.
 * `pom_file`: *Recommended.* The path to the pom.xml to deploy with the artifact.
 
 * `version_file`: *Required.* The path to the version file
+
+* `files`: *Optional.* Map of paths to auxillary artifacts to upload alongside the primary artifact. Takes the form _classifier: artifact/path-to-artifact_. The packing type will be deduced from the file extension. **Warning**: you will need to be careful with your glob pattern when specifying auxillary artifacts. You'll need to discern between the different file paths. For example, if your primary artifact is `my-artifact-0.2.3.beta-rc.7.jar`, your glob pattern will need to be...
+
+```yaml
+- put: artifact
+  params:
+    file: artifact/my-artifact-*[0-9].*[0-9].*[0-9]-beta.*[0-9].jar
+    files:
+      javadoc: artifact/my-artifact-*-javadoc.jar
+```
 
 ## Examples
 
@@ -118,4 +142,27 @@ jobs:
     params:
       manifest: source-code/manifest.yml
       path: artifact/example-webapp-*.jar
+```
+
+Retrieve an artifact along with auxillary artifacts, then deploy with a GitHub release:
+
+``` yaml
+jobs:
+- name: my-job
+  plan:
+  - get: source-code
+  - get: artifact
+    trigger: true
+    params:
+      artifactItems:
+        javadoc: jar
+        stubs: jar
+        diagram: pdf
+  - task: generate-github-release
+    file: pipeline-tasks/generate-github-release/task.yml
+  - put: gh-release
+    params:
+      name: task-output/release-name
+      tag: task-output/release-tag
+      globs: [artifact/example-webapp-*]
 ```

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -1,3 +1,5 @@
+function join { local IFS="$1"; shift; echo "$*"; }
+
 get_group_id() {
   echo $1 | cut -d ":" -f 1
 }

--- a/assets/in
+++ b/assets/in
@@ -34,6 +34,7 @@ fi
 release_url=$(jq -r '.source.url //empty' < $payload)
 snapshot_url=$(jq -r '.source.snapshot_url //empty' < $payload)
 artifact=$(jq -r '.source.artifact //empty' < $payload)
+artifactItems=$(jq -r '.params.artifactItems //empty' < $payload)
 version=$(jq -r '.version.version //empty' < $payload)
 username=$(jq -r '.source.username //empty' < $payload)
 password=$(jq -r '.source.password //empty' < $payload)
@@ -92,14 +93,25 @@ url=$release_url
 [ -n "$snapshot_url" ] && [ "$isSnapshot" = true ] && url=$snapshot_url
 
 args=
-args="$args -Dartifact=$artifactItem"
 args="$args -DoutputDirectory=$destination"
 args="$args -Drepository.url=$url"
 
 [ -n "$username" ] && args="$args -Drepository.username=$username";
 [ -n "$password" ] && args="$args -Drepository.password=$password";
 
-$resource_dir/mvnw dependency:copy $args
+$resource_dir/mvnw dependency:copy "$args -Dartifact=$artifactItem"
+
+# Deconstruct map of 'classifier: type' objects, and download
+# corresponding maven repo objects using 'groupId:artifactId' and 'args'
+# from the "primary" artifact
+if [ -n "$artifactItems" ]; then
+  for classifier in $( jq -r 'keys[]' <<< $artifactItems ); do
+    packaging=$(jq -r ".[\"$classifier\"]" <<< $artifactItems)
+    artifactExtra="$groupId:$artifactId:$version:$packaging:$classifier"
+    $resource_dir/mvnw dependency:copy "$args -Dartifact=$artifactExtra"
+  done
+fi
+
 
 jq -n \
 --arg version "$version" \

--- a/assets/out
+++ b/assets/out
@@ -81,6 +81,19 @@ fi
 file=$(ls $file)
 pom_file=$(ls $pom_file)
 
+files=''
+classifiers=''
+types=''
+artifactItems=$( jq -r '.params.files //empty' < $payload )
+if [ -n "$artifactItems" ]; then
+  for classifier_key in $(jq -r 'keys[]' <<< $artifactItems); do
+    classifiers=$(join , $classifiers $classifier_key)
+    curr_file=$(jq -r ".[\"$classifier_key\"]" <<< $artifactItems )
+    files=$(join , $files $curr_file)
+    types=$(join , $types ${curr_file##*.})
+  done
+fi;
+
 if [ -f "$version_file" ]; then
   version=$(cat $version_file)
 elif [ -f "$pom_file" ]; then
@@ -158,6 +171,10 @@ args="$args -Dpackaging=$packaging"
 [ -n "$classifier" ] && args="$args -Dclassifier=$classifier"
 [ -n "$username" ]   && args="$args -Drepository.username=$username";
 [ -n "$password" ]   && args="$args -Drepository.password=$password";
+
+[ -n "$files" ]   && args="$args -Dfiles=$files";
+[ -n "$classifiers" ]   && args="$args -Dclassifiers=$classifiers";
+[ -n "$types" ]   && args="$args -Dtypes=$types";
 
 $resource_dir/mvnw deploy:deploy-file $args
 


### PR DESCRIPTION
(Updated & ready for actual consideration)

In our deployments, we'd like to include `files`, such as `javadoc` or `sources` or `stubs`. I was inspired by [this issue on Patrick's upstream repository.](https://github.com/patrickcrocker/maven-resource/issues/14)

You can `get` artifacts auxiliary to the primary artifact:

```yaml
jobs:
- name: my-job
  plan:
  - get: source-code
  - get: artifact
    trigger: true
    params:
      artifactItems:
        javadoc: jar
        stubs: jar
        diagram: pdf
```

You can `put` artifact files auxiliary to the primary artifact:

```yaml
- put: maven-milestone
      params:
        # matches only on some-artifact-name-0-0-1.beta.12.jar
        file: artifact/my-artifact-*[0-9].*[0-9].*[0-9]-beta.*[0-9].jar
        files:
          javadoc: artifact/my-artifact-*-javadoc.jar
          sources: artifact/my-artifact-*-sources.jar
        pom_file: project/pom.xml
        version_file: version/version
```

This will only `check` on the "primary" artifact specified in `source`. 

Here's the docker image I'm using for my changes: https://hub.docker.com/r/aegershman/maven-resource-with-classifiers/